### PR TITLE
fix: allow setting 0 (zero) as maxAge

### DIFF
--- a/src/cache-control.decorator.ts
+++ b/src/cache-control.decorator.ts
@@ -12,7 +12,7 @@ export const CacheControl = ({
   inheritMaxAge,
 }: CacheControlOptions) =>
   Directive(
-    `@cacheControl(scope: ${scope}${maxAge ? `, maxAge: ${maxAge}` : ''}${
+    `@cacheControl(scope: ${scope}${maxAge !== undefined ? `, maxAge: ${maxAge}` : ''}${
       inheritMaxAge ? `, inheritMaxAge: ${inheritMaxAge}` : ''
     })`
   );


### PR DESCRIPTION
It is currently impossible to set maxAge to 0, since the maxAge ? check will return false if you pass in 0. This PR fixes that.